### PR TITLE
Check if $id is non-zero

### DIFF
--- a/linux/uninstall.sh
+++ b/linux/uninstall.sh
@@ -19,7 +19,7 @@ rm ~/.config/chromium/NativeMessagingHosts/${id}.json
 echo " .. Removing manifest file for Mozilla Firefox"
 rm ~/.mozilla/native-messaging-hosts/${id}.json
 echo " .. Removing executable"
-rm -r ~/.config/${id}
+[ -n "$id" ] && rm -r ~/.config/${id}
 
 echo
 echo ">>> Native Client is removed <<<".


### PR DESCRIPTION
I suspect you package non-statically compiled Node, so it doesn't work on systems which don't have glibc, e.g. Voidlinux.
This causes $id to be an empty variable.
This means `rm -r ~/.config/`.
Yep, I just deleted my entire ~/.config directory by running your script.