### PR TITLE
Fix for command spawning when executable path contains spaces/arguments (e.g. Flatpaks)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,13 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script
@@ -31,42 +33,14 @@ jobs:
           cd ../windows
           zip ../windows.zip -9 -r * -x "*.DS_Store"
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release and Upload Assets
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: Release ${{ github.ref }}
           draft: false
           prerelease: true
-
-      - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./windows.zip
-          asset_name: windows.zip
-          asset_content_type: application/zip
-      - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./linux.zip
-          asset_name: linux.zip
-          asset_content_type: application/zip
-
-      - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./mac.zip
-          asset_name: mac.zip
-          asset_content_type: application/zip
+          files: |
+            windows.zip
+            linux.zip
+            mac.zip

--- a/config.js
+++ b/config.js
@@ -1,51 +1,51 @@
-'use strict';
+"use strict";
 
-exports.id = 'com.add0n.native_client';
-exports.version = '0.4.7';
+exports.id = "com.add0n.native_client";
+exports.version = "0.4.8";
 
 exports.ids = {
   chrome: [
-    'hfckgfbhdacemicpjljhfbjmkiggeche', // Send to VLC (Chrome)
-    'lgbipmmmnjifkiiikaffhceflifbmhib', // Download with IDM (Chrome)
-    'jlodlegnpjplclncjkgolcmdhjmlokna', // Download with FDM (Chrome)
-    'jfpmbokkdeapjommajdfmmheiiakdlgo', // Download with JDownloader (Chrome)
-    'hlbdmmifbcfpccdnoknhdfcifiglaihb', // Download with DAP (Chrome)
-    'eiejadjdcchfommckmikpcdnihljbpai', // Edit with Sublime Text (Chrome)
-    'gpmjpkmohjgaimfhebdjebpgdnpcadji', // Edit with Notepad++ (Chrome)
+    "hfckgfbhdacemicpjljhfbjmkiggeche", // Send to VLC (Chrome)
+    "lgbipmmmnjifkiiikaffhceflifbmhib", // Download with IDM (Chrome)
+    "jlodlegnpjplclncjkgolcmdhjmlokna", // Download with FDM (Chrome)
+    "jfpmbokkdeapjommajdfmmheiiakdlgo", // Download with JDownloader (Chrome)
+    "hlbdmmifbcfpccdnoknhdfcifiglaihb", // Download with DAP (Chrome)
+    "eiejadjdcchfommckmikpcdnihljbpai", // Edit with Sublime Text (Chrome)
+    "gpmjpkmohjgaimfhebdjebpgdnpcadji", // Edit with Notepad++ (Chrome)
 
-    'hgadfjhoalnaidfdoilgeimnolhcodbc', // Send to VLC (Opera)
-    'ngaohleapbfjleillajbginbiaokmncm', // Send to MPC (Opera)
-    'kalnbllmkdiidgakcakkoecaahkpakmj', // Send to MPlayer (Opera)
-    'kajaikkhnmegmfnlifeklklaienhdekb', // Download with IDM (Opera)
-    'iidhcgjgmjodnfbghbgpdnhiajbmgcjo', // Download with FDM (Opera)
-    'jjbbcngfknmgdlekfofhaagmogeifbpc', // Download with JDownloader (Opera)
-    'ekeecmblpnobdaijmfkcfcnofopooipg', // Download with DAP (Opera)
-    'ilonanfdcnaljoedndpfeflllibalflj', // Download with JDownloader (Edge)
-    'cmddfbnhpokddncdalabdlmdckcdmboh', // Download with Wget (Opera)
-    'gecfhmlaldelfoeahjahajoooenmnlnd', // Download with FlashGet (Opera)
-    'eadfknilcdakacgehgfoedimdghaedgi', // Download with FlashGet (Opera)
-    'odbhmaaphiednnbgfionolmpkdplpilc', // Edit with Sublime Text (Opera)
-    'hfgnckeamhbkolmfeaieemklhejdcmai', // Edit with Notepad++ (Opera)
-    'dbghnkdojpkebjbddhhjfjgapoolnikh', // Send to MPV (Opera)
-    'ajcbbbkgmbinpbkllamhphpgpgdabnhf', // Edit with VIM (Opera)
+    "hgadfjhoalnaidfdoilgeimnolhcodbc", // Send to VLC (Opera)
+    "ngaohleapbfjleillajbginbiaokmncm", // Send to MPC (Opera)
+    "kalnbllmkdiidgakcakkoecaahkpakmj", // Send to MPlayer (Opera)
+    "kajaikkhnmegmfnlifeklklaienhdekb", // Download with IDM (Opera)
+    "iidhcgjgmjodnfbghbgpdnhiajbmgcjo", // Download with FDM (Opera)
+    "jjbbcngfknmgdlekfofhaagmogeifbpc", // Download with JDownloader (Opera)
+    "ekeecmblpnobdaijmfkcfcnofopooipg", // Download with DAP (Opera)
+    "ilonanfdcnaljoedndpfeflllibalflj", // Download with JDownloader (Edge)
+    "cmddfbnhpokddncdalabdlmdckcdmboh", // Download with Wget (Opera)
+    "gecfhmlaldelfoeahjahajoooenmnlnd", // Download with FlashGet (Opera)
+    "eadfknilcdakacgehgfoedimdghaedgi", // Download with FlashGet (Opera)
+    "odbhmaaphiednnbgfionolmpkdplpilc", // Edit with Sublime Text (Opera)
+    "hfgnckeamhbkolmfeaieemklhejdcmai", // Edit with Notepad++ (Opera)
+    "dbghnkdojpkebjbddhhjfjgapoolnikh", // Send to MPV (Opera)
+    "ajcbbbkgmbinpbkllamhphpgpgdabnhf", // Edit with VIM (Opera)
 
-    'iiekfngbnhgiecdjekibkbkaecdneobh', // Edit with Sublime Text (Edge)
-    'bihikkbcagnajdoncmjebpalfhecpjnb', // Download with IDM (Edge)
+    "iiekfngbnhgiecdjekibkbkaecdneobh", // Edit with Sublime Text (Edge)
+    "bihikkbcagnajdoncmjebpalfhecpjnb", // Download with IDM (Edge)
   ],
   firefox: [
-    '{3e0ac434-26e0-4c03-b757-3078486800c3}', // Send to VLC
-    '{cee1ccee-5508-4927-a929-9a557e63bbc8}', // Send to MPC
-    '{ccad95df-add6-4d8a-aa5c-cdc384075bab}', // Send to MPV
-    '{c7636e52-8aba-4717-9652-01922ee61eb3}', // Send to MPlayer media player
-    '{d1646fcf-76ad-49c5-b8b2-e496e9b71189}', // Download with IDM
-    '{cfd8df21-e05f-46e9-8ea1-af5e5177d492}', // Download with DAP
-    '{1fb1ffdc-b95d-451e-be52-7303adf9a0d3}', // Download with FDM
-    '{533953f8-ffb6-421c-af1a-5a02a792ab51}', // Download with Wget
-    '{48f5395d-5c00-41cd-9a5e-fd2f8d9b74c2}', // Download with FlashGet
-    '{03e07985-30b0-4ae0-8b3e-0c7519b9bdf6}', // Download with JDownloader
-    '{708bb4c5-336d-4a30-9126-8bf5d773bb41}', // Download with aria2
-    '{5510b212-951a-439c-ae73-b1ebbc68055f}', // Edit with Sublime Text
-    '{f91bc9ee-ae11-4850-8e6b-ed4b0262ce3b}', // Edit with Notepad++
-    '{dc393f22-0d98-44d4-8a2c-9dd72208e9f7}', // Edit with VIM
-  ]
+    "{3e0ac434-26e0-4c03-b757-3078486800c3}", // Send to VLC
+    "{cee1ccee-5508-4927-a929-9a557e63bbc8}", // Send to MPC
+    "{ccad95df-add6-4d8a-aa5c-cdc384075bab}", // Send to MPV
+    "{c7636e52-8aba-4717-9652-01922ee61eb3}", // Send to MPlayer media player
+    "{d1646fcf-76ad-49c5-b8b2-e496e9b71189}", // Download with IDM
+    "{cfd8df21-e05f-46e9-8ea1-af5e5177d492}", // Download with DAP
+    "{1fb1ffdc-b95d-451e-be52-7303adf9a0d3}", // Download with FDM
+    "{533953f8-ffb6-421c-af1a-5a02a792ab51}", // Download with Wget
+    "{48f5395d-5c00-41cd-9a5e-fd2f8d9b74c2}", // Download with FlashGet
+    "{03e07985-30b0-4ae0-8b3e-0c7519b9bdf6}", // Download with JDownloader
+    "{708bb4c5-336d-4a30-9126-8bf5d773bb41}", // Download with aria2
+    "{5510b212-951a-439c-ae73-b1ebbc68055f}", // Edit with Sublime Text
+    "{f91bc9ee-ae11-4850-8e6b-ed4b0262ce3b}", // Edit with Notepad++
+    "{dc393f22-0d98-44d4-8a2c-9dd72208e9f7}", // Edit with VIM
+  ],
 };

--- a/host.js
+++ b/host.js
@@ -1,29 +1,117 @@
-'use strict';
+"use strict";
 
-const config = require('./config.js');
+const config = require("./config.js");
 
 // closing node when parent process is killed
 process.stdin.resume();
-process.stdin.on('end', () => process.exit());
+process.stdin.on("end", () => process.exit());
+
+function parseCommandLine(cmdStr) {
+  const parsedArgs = [];
+  let current = "";
+  let inDoubleQuote = false;
+  let inSingleQuote = false;
+  let escaped = false;
+
+  for (let i = 0; i < cmdStr.length; i++) {
+    const char = cmdStr[i];
+
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\" && process.platform !== "win32") {
+      if (inSingleQuote) {
+        current += char;
+      } else {
+        escaped = true;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      if (inSingleQuote) {
+        current += char;
+      } else {
+        inDoubleQuote = !inDoubleQuote;
+      }
+      continue;
+    }
+
+    if (char === "'") {
+      if (inDoubleQuote) {
+        current += char;
+      } else {
+        inSingleQuote = !inSingleQuote;
+      }
+      continue;
+    }
+
+    if (char === " " || char === "\t") {
+      if (inDoubleQuote || inSingleQuote) {
+        current += char;
+      } else {
+        if (current) {
+          parsedArgs.push(current);
+          current = "";
+        }
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current) {
+    parsedArgs.push(current);
+  }
+
+  return parsedArgs;
+}
+
+function wrapChildProcess(cp) {
+  return new Proxy(cp, {
+    get(target, prop, receiver) {
+      if (prop === "spawn") {
+        return function (command, args, options) {
+          const parts = parseCommandLine(command);
+          if (parts.length > 1) {
+            const finalCommand = parts[0];
+            const finalArgs = parts.slice(1).concat(args || []);
+            return target.spawn(finalCommand, finalArgs, options);
+          }
+          return target.spawn(command, args, options);
+        };
+      }
+      const val = Reflect.get(target, prop, receiver);
+      if (typeof val === "function") {
+        return val.bind(target);
+      }
+      return val;
+    },
+  });
+}
 
 function observe(request, push, done) {
   let close;
-  const exception = e => {
+  const exception = (e) => {
     push({
       code: -1,
-      type: 'exception',
-      error: e.stack
+      type: "exception",
+      error: e.stack,
     });
     close();
   };
   close = () => {
-    process.removeListener('uncaughtException', exception);
+    process.removeListener("uncaughtException", exception);
     done();
     close = () => {};
   };
-  process.addListener('uncaughtException', exception);
+  process.addListener("uncaughtException", exception);
 
-  if (request.method === 'spec') {
+  if (request.method === "spec") {
     push({
       version: config.version,
       env: process.env,
@@ -31,13 +119,12 @@ function observe(request, push, done) {
       platform: process.platform,
       arch: process.arch,
       versions: process.versions,
-      separator: require('path').sep,
-      tmpdir: require('os').tmpdir()
+      separator: require("path").sep,
+      tmpdir: require("os").tmpdir(),
     });
     close();
-  }
-  else if ('script' in request) {
-    const vm = require('vm');
+  } else if ("script" in request) {
+    const vm = require("vm");
     const sandbox = {
       version: config.version,
       env: process.env,
@@ -46,22 +133,30 @@ function observe(request, push, done) {
       setTimeout,
       args: request.args,
       // only allow internal modules that extension already requested permission for
-      require: name => (request.permissions || []).indexOf(name) === -1 ? null : require(name)
+      require: (name) => {
+        if ((request.permissions || []).indexOf(name) === -1) {
+          return null;
+        }
+        const mod = require(name);
+        if (name === "child_process") {
+          return wrapChildProcess(mod);
+        }
+        return mod;
+      },
     };
     const script = new vm.Script(request.script);
     const context = new vm.createContext(sandbox);
     script.runInContext(context);
-  }
-  else {
+  } else {
     push({
-      type: 'context',
-      error: 'cannot find "script" key in your request. Closing connection...'
+      type: "context",
+      error: 'cannot find "script" key in your request. Closing connection...',
     });
     close();
   }
 }
 /* message passing */
-const nativeMessage = require('./messaging');
+const nativeMessage = require("./messaging");
 process.stdin
   .pipe(new nativeMessage.Input())
   .pipe(new nativeMessage.Transform(observe))


### PR DESCRIPTION
## Problem

When configuring a browser extension to execute an application with arguments (such as using a Flatpak executable on Linux, e.g., `/usr/bin/flatpak run --branch=stable --arch=x86_64 org.freedownloadmanager.Manager`), the command fails to launch with an `ENOENT` error.

This happens because `child_process.spawn()` treats the entire string passed as the first argument as the command name (executable path). If this string contains spaces or arguments, Node.js tries to search for an executable with that exact long name, which does not exist on the filesystem.

## Solution

To resolve this issue globally for any scripts running within the `com.add0n.native_client` VM sandbox, we intercept calls to the `child_process` module using a Proxy:

1. Added a robust shell-like command-line parser that splits the command string into an array of arguments, handling platform-specific escaping and quoting.
2. Created a Proxy wrapper for the `child_process` module. When `spawn()` is called, the proxy intercepts the invocation:
   - If the first argument (`command`) contains multiple space-separated parts (arguments), it splits them.
   - It separates the actual executable binary from its parameters and prepends those parameters to the child process argument list.
3. Updated the custom `require` function inside the VM sandbox setup to return this wrapped `child_process` module instead of the raw module.

This ensures that any commands with arguments can be successfully parsed and launched by the native host wrapper.
